### PR TITLE
feat: support webm avatars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.1.2
+- Allow webm files for actor portraits
+
 ### 3.1.1
 - Add setting to move stage to the top when there are more than 5 actors
 

--- a/src/scripts/Theatre.js
+++ b/src/scripts/Theatre.js
@@ -1852,6 +1852,12 @@ export class Theatre {
         // use normal sprite if it's not a gif
         if (!texture.animationSpeed) {
             sprite = new PIXI.Sprite(texture);
+            const source = sprite.texture?.baseTexture?.resource?.source;
+            if (source instanceof HTMLVideoElement) {
+                source.loop = true;
+                source.muted = true;
+                source.play();
+            }
         } else {
             sprite = texture.clone();
         }
@@ -2461,6 +2467,12 @@ export class Theatre {
         // use normal sprite if it's not a gif
         if (!resources[resName].animationSpeed) {
             sprite = new PIXI.Sprite(resources[resName]);
+            const source = sprite.texture?.baseTexture?.resource?.source;
+            if (source instanceof HTMLVideoElement) {
+                source.loop = true;
+                source.muted = true;
+                source.play();
+            }
         } else {
             sprite = resources[resName].clone();
         }

--- a/src/scripts/TheatreActorConfig.js
+++ b/src/scripts/TheatreActorConfig.js
@@ -581,7 +581,7 @@ export class TheatreActorConfig extends FormApplication {
     _onCustomIconImage(ev) {
         let target = ev.currentTarget;
         new FilePicker({
-            type: "image",
+            type: "imagevideo",
             current: target.getAttribute("src"),
             callback: (path) => {
                 target.src = path;

--- a/src/templates/theatre_actor_config.html
+++ b/src/templates/theatre_actor_config.html
@@ -52,7 +52,7 @@
                                                 draggable="false" />
                                         {{else}}<img src="{{em.image}}" draggable="false" />{{/if}}
                                     {{else}}<i class="{{em.fatype}} {{em.faname}}"></i>{{/if}}</div>
-                                {{filePicker type="image" target=(cat (cat "flags.theatre.emotes." key) ".insert")}}<input
+                                {{filePicker type="imagevideo" target=(cat (cat "flags.theatre.emotes." key) ".insert")}}<input
                                     class="image" type="text" name="flags.theatre.emotes.{{key}}.insert"
                                     placeholder="{{localize 'Theatre.UI.Config.PathPlaceholder'}}"
                                     value="{{resprop (cat (cat 'object.flags.theatre.emotes.' key) '.insert')}}"


### PR DESCRIPTION
## Summary
- allow choosing video files for emotes
- auto-play webm video textures for avatar portraits and tooltips
- document webm avatar support

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c59cb782e4832f9814599f2978280d