### PR TITLE
Allow video emotes and enable custom emote deletion

### DIFF
--- a/src/scripts/TheatreActorConfig.js
+++ b/src/scripts/TheatreActorConfig.js
@@ -338,6 +338,8 @@ export class TheatreActorConfig extends FormApplication {
         }
         // send the emote parent in bulk to get rid of unwanted children
         revisedFormData["flags.theatre.emotes"] = nEmotes;
+        // merge explicit emote updates such as deletions into final payload
+        foundry.utils.mergeObject(revisedFormData, emoteFormData);
         Logger.debug("Final Push Config update:", revisedFormData);
 
         this.object.update(revisedFormData).then((response) => {
@@ -518,7 +520,8 @@ export class TheatreActorConfig extends FormApplication {
         KHelpers.addClass(fileIcon, "fas");
         KHelpers.addClass(fileIcon, "fa-file-import");
         KHelpers.addClass(fileIcon, "fa-fw");
-        KHelpers.addClass(fileInput, "image");
+        // Allow both images and videos to be selected for custom emote inserts
+        KHelpers.addClass(fileInput, "imagevideo");
         //KHelpers.addClass(editEmoteButton,"theatre-config-btn-edit-emote");
         //KHelpers.addClass(editEmoteIcon,"fas");
         //KHelpers.addClass(editEmoteIcon,"fa-sliders-h");
@@ -533,7 +536,8 @@ export class TheatreActorConfig extends FormApplication {
         emoteNameInput.addEventListener("focusout", this._onCustomLabelInputFocusOut.bind(this));
 
         fileButton.setAttribute("type", "button");
-        fileButton.setAttribute("data-type", "image");
+        // Use imagevideo to enable selecting videos in addition to images
+        fileButton.setAttribute("data-type", "imagevideo");
         fileButton.setAttribute("data-target", `flags.theatre.emotes.${customName}.insert`);
         fileButton.setAttribute("title", "Browse Files");
         fileButton.setAttribute("tabindex", "-1");

--- a/src/templates/theatre_actor_config.html
+++ b/src/templates/theatre_actor_config.html
@@ -53,7 +53,7 @@
                                         {{else}}<img src="{{em.image}}" draggable="false" />{{/if}}
                                     {{else}}<i class="{{em.fatype}} {{em.faname}}"></i>{{/if}}</div>
                                 {{filePicker type="imagevideo" target=(cat (cat "flags.theatre.emotes." key) ".insert")}}<input
-                                    class="image" type="text" name="flags.theatre.emotes.{{key}}.insert"
+                                    class="imagevideo" type="text" name="flags.theatre.emotes.{{key}}.insert"
                                     placeholder="{{localize 'Theatre.UI.Config.PathPlaceholder'}}"
                                     value="{{resprop (cat (cat 'object.flags.theatre.emotes.' key) '.insert')}}"
                                     data-dtype="String" />


### PR DESCRIPTION
## Summary
- let custom emote file pickers accept videos
- ensure flagged custom emotes are removed on save

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5b4722448832f952dd22b8cccd589