### PR TITLE
chore: downgrade resync warning

### DIFF
--- a/src/scripts/Theatre.js
+++ b/src/scripts/Theatre.js
@@ -703,7 +703,7 @@ export class Theatre {
         Logger.debug("Processing resync request");
         // If the dock is not active, no need to send anything
         if (type == "any" && this.dockActive <= 0 && !this.isNarratorActive) {
-            Logger.warn("OUR DOCK IS NOT ACTIVE, Not responding to reqresync");
+            Logger.debug("Dock not active; ignoring resync request");
             return;
         } else if (type == "gm" && !game.user.isGM) {
             return;

--- a/src/scripts/TheatreActorConfig.js
+++ b/src/scripts/TheatreActorConfig.js
@@ -23,6 +23,9 @@ import { Theatre } from "./Theatre.js";
 import CONSTANTS from "./constants/constants.js";
 import Logger from "./lib/Logger.js";
 
+// Use Application framework V2 when available to avoid deprecation warnings
+const TheatreFormApplication = foundry.applications?.api?.FormApplication ?? FormApplication;
+
 /**
  * ============================================================
  * Application to configure Actor Theatre-Inserts
@@ -33,7 +36,7 @@ import Logger from "./lib/Logger.js";
  *
  * ============================================================
  */
-export class TheatreActorConfig extends FormApplication {
+export class TheatreActorConfig extends TheatreFormApplication {
     constructor(object = {}, options = {}) {
         if (object._theatre_mod_configTab) {
             options.tabs = [
@@ -77,12 +80,17 @@ export class TheatreActorConfig extends FormApplication {
      */
     getData() {
         const entityName = this.object.name;
+        const alignChoices = {
+            top: "Theatre.UI.Config.SetTopAlignTop",
+            bottom: "Theatre.UI.Config.SetTopAlignBottom",
+        };
         return {
             entityName: entityName,
             isGM: game.user.isGM,
             object: foundry.utils.duplicate(this.object),
             emote: Theatre.getActorEmotes(this.object._id),
             options: this.options,
+            alignChoices: alignChoices,
         };
     }
 

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -3,6 +3,9 @@ import { TheatreHelpers } from "./theatre-helpers.js";
 import CONSTANTS from "./constants/constants.js";
 import Logger from "./lib/Logger.js";
 
+// Prefer Application framework V2 when available to avoid deprecation warnings
+const BaseFormApplication = foundry.applications?.api?.FormApplication ?? FormApplication;
+
 export const registerSettings = function () {
     let settingsCustom = {};
     // game.settings.registerMenu(CONSTANTS.MODULE_ID, "resetAllSettings", {
@@ -302,7 +305,7 @@ export const registerSettings = function () {
     return settingsCustom;
 };
 
-class ResetSettingsDialog extends FormApplication {
+class ResetSettingsDialog extends BaseFormApplication {
     constructor(...args) {
         //@ts-ignore
         super(...args);

--- a/src/templates/theatre_actor_config.html
+++ b/src/templates/theatre_actor_config.html
@@ -15,10 +15,9 @@
                         value="{{object.flags.theatre.name}}" /></div>
                 <p class="notes"> {{localize "Theatre.UI.Config.SetTopAlign"}}</p>
                 <div class="form-group"><select name="flags.theatre.optalign"
-                        data-dtype="String">{{#select object.flags.theatre.optalign}}
-                            <option value="top">{{localize "Theatre.UI.Config.SetTopAlignTop"}}</option>
-                            <option value="bottom">{{localize "Theatre.UI.Config.SetTopAlignBottom"}}</option>
-                        {{/select}}</select></div>
+                        data-dtype="String">
+                            {{selectOptions alignChoices selected=object.flags.theatre.optalign localize=true}}
+                        </select></div>
                 <p class="notes"> {{localize "Theatre.UI.Config.SetDefaultInsert"}}</p>
                 <div class="form-group">
                     <label>{{localize "Theatre.UI.Config.BaseInsert"}}</label>{{filePicker type="imagevideo" target="flags.theatre.baseinsert"}}<input


### PR DESCRIPTION
## Summary
- log dock inactivity during resync at debug level instead of warn
- prefer Application framework V2 to avoid deprecation warnings
- replace deprecated Handlebars select helper with selectOptions

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5b78324ac832f981f802eeadee761