### PR TITLE
Mirror left avatars automatically

### DIFF
--- a/src/scripts/Theatre.js
+++ b/src/scripts/Theatre.js
@@ -2384,7 +2384,7 @@ export class Theatre {
             typingBubble: null,
             exitOrientation: isLeft ? "left" : "right",
             nameOrientation: "left",
-            mirrored: false,
+            mirrored: isLeft,
             optAlign: optAlign,
             tweens: {},
             order: 0,


### PR DESCRIPTION
## Summary
- Mirror inserts spawned on the left so portraits face the center by default

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c65545f5e8832fb768d86c2a7d41fc